### PR TITLE
Fix typos on 'starter'

### DIFF
--- a/src/routes/stats/[handle]/+page.svelte
+++ b/src/routes/stats/[handle]/+page.svelte
@@ -789,7 +789,7 @@
     <div class="card bg-base-300 p-4">
       <div class="flex items-start justify-between">
         <h3 class="mb-4 text-lg font-bold">
-          In Stater Pack
+          In Starter Pack
           <span class="text-xs text-base-content/50"> (in the Skyzoo known packs)</span>
         </h3>
         <div class="stat-value text-primary">


### PR DESCRIPTION
Just fixing a minor typos I spotted while browsing the page